### PR TITLE
docs: Add CODE_OF_CONDUCT.md and CONTRIBUTING.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,50 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+https://github.com/Scottcjn.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Contributing to NVIDIA POWER8 Patches
+
+Thank you for your interest in contributing to NVIDIA POWER8 Patches! This document provides guidelines and instructions for contributing.
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md). By participating, you agree to uphold this code.
+
+## How to Contribute
+
+### Reporting Issues
+
+- Check existing issues before creating a new one
+- Use clear, descriptive titles
+- Include system details (POWER8 model, NVIDIA GPU, driver version)
+- Provide steps to reproduce any bugs
+
+### Submitting Patches
+
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/your-feature`)
+3. Make your changes
+4. Test on POWER8 hardware if possible
+5. Commit your changes (`git commit -m 'Add some feature'`)
+6. Push to the branch (`git push origin feature/your-feature`)
+7. Open a Pull Request
+
+### Code Style
+
+- Follow Linux kernel coding style for C code
+- Use 8-space tabs for indentation
+- Keep lines under 100 characters
+- Add comments for POWER8-specific code
+
+### Testing
+
+Before submitting a PR:
+
+1. Verify syntax: `gcc -fsyntax-only your-file.c`
+2. Test build on POWER8 if available
+3. Run `nvidia-smi` to verify driver loads correctly
+
+## Development Setup
+
+### Prerequisites
+
+- IBM POWER8/9/10 system
+- NVIDIA GPU (supported models)
+- CUDA toolkit
+- GCC compiler
+- Linux kernel headers
+
+### Building
+
+```bash
+# Clone your fork
+git clone https://github.com/YOUR_USERNAME/nvidia-power8-patches.git
+cd nvidia-power8-patches
+
+# Apply patches to NVIDIA driver source
+./apply-patches.sh /path/to/nvidia-driver-source
+
+# Build
+cd /path/to/nvidia-driver-source
+make
+sudo make install
+```
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the MIT License.
+
+---
+
+🤝 Generated for the POWER8 community


### PR DESCRIPTION
## Summary

This PR adds community documentation files for the NVIDIA POWER8 Patches project.

## Changes

- ✅ CODE_OF_CONDUCT.md - Contributor Covenant v2.0
- ✅ CONTRIBUTING.md with:
  - Issue reporting guidelines
  - Code style (Linux kernel style)
  - Build instructions
  - Testing procedures

Closes #2
Closes #3

🤖 Generated by Claw (AI Agent)