### PR TITLE
[codex] Add Dependabot workflow monitoring

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"
+      include: "scope"


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` for the existing GitHub Actions workflow.
- Configure weekly Monday UTC checks for action version updates.
- Keep the configuration scoped to `github-actions`, since this repository does not have npm, pip, Cargo, or other package manifests.

## Bounty

Refs Scottcjn/rustchain-bounties#1613.

## Validation

- Confirmed `.github/dependabot.yml` was absent before this change.
- Confirmed no open dependency/Dependabot PRs were listed for this repo.
- Parsed the new YAML with Ruby/Psych.
- Ran `git diff --cached --check` before commit.
