### PR TITLE
Fix RustChain branding in README footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ For questions or contributions:
 
 **[Elyan Labs](https://github.com/Scottcjn)** · 1,882 commits · 97 repos · 1,334 stars · $0 raised
 
-[⭐ Star Rustchain](https://github.com/Scottcjn/Rustchain) · [📊 Q1 2026 Traction Report](https://github.com/Scottcjn/Rustchain/blob/main/docs/DEVELOPER_TRACTION_Q1_2026.md) · [Follow @Scottcjn](https://github.com/Scottcjn)
+[⭐ Star RustChain](https://github.com/Scottcjn/Rustchain) · [📊 Q1 2026 Traction Report](https://github.com/Scottcjn/Rustchain/blob/main/docs/DEVELOPER_TRACTION_Q1_2026.md) · [Follow @Scottcjn](https://github.com/Scottcjn)
 
 </div>
 


### PR DESCRIPTION
## Summary
- update the README footer link text from `Star Rustchain` to `Star RustChain`

## Validation
- `git diff --check`
- duplicate check: open PR list only showed unrelated Dependabot workflow PR #16
- duplicate check: open branding/capitalization PR search returned no hits
- duplicate check: rustchain-bounties #2178 comments had no nvidia-power8-patches submission before this PR