### PR TITLE
docs: fix BCOS badge link

### DIFF
--- a/BCOS.md
+++ b/BCOS.md
@@ -1,6 +1,6 @@
 # BCOS — Blockchain Certified Open Source
 
-[![BCOS Certified](https://img.shields.io/badge/BCOS-Certified-brightgreen?style=flat&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0id2hpdGUiPjxwYXRoIGQ9Ik0xMiAxTDMgNXY2YzAgNS41NSAzLjg0IDEwLjc0IDkgMTIgNS4xNi0xLjI2IDktNi40NSA5LTEyVjVsLTktNHptLTIgMTZsLTQtNCA1LjQxLTUuNDEgMS40MSAxLjQxTDEwIDE0bDYtNiAxLjQxIDEuNDFMMTAgMTd6Ii8+PC9zdmc+)](https://github.com/nicholaelaw/awesome-bcos)
+[![BCOS Certified](https://img.shields.io/badge/BCOS-Certified-brightgreen?style=flat&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0id2hpdGUiPjxwYXRoIGQ9Ik0xMiAxTDMgNXY2YzAgNS41NSAzLjg0IDEwLjc0IDkgMTIgNS4xNi0xLjI2IDktNi40NSA5LTEyVjVsLTktNHptLTIgMTZsLTQtNCA1LjQxLTUuNDEgMS40MSAxLjQxTDEwIDE0bDYtNiAxLjQxIDEuNDFMMTAgMTd6Ii8+PC9zdmc+)](https://github.com/Scottcjn/Rustchain/blob/main/BCOS.md)
 
 ## What is BCOS?
 


### PR DESCRIPTION
## Summary
- update the BCOS certification badge target from the missing `nicholaelaw/awesome-bcos` repository to the current RustChain BCOS documentation

## Validation
- `curl -L https://github.com/nicholaelaw/awesome-bcos` returns 404
- `curl -L https://github.com/Scottcjn/Rustchain/blob/main/BCOS.md` returns 200
- `git diff --check`

Bounty: Scottcjn/rustchain-bounties#444